### PR TITLE
fix: local.GroupUpdate cannot update empty description

### DIFF
--- a/windows/local/local_group.go
+++ b/windows/local/local_group.go
@@ -154,7 +154,12 @@ func (c *LocalClient) GroupUpdate(ctx context.Context, params GroupUpdateParams)
 		cmds = append(cmds, fmt.Sprintf("-Name '%s'", params.Name))
 	}
 
-	cmds = append(cmds, fmt.Sprintf("-Description '%s'", params.Description))
+	if params.Description == "" {
+		cmds = append(cmds, "-Description ' '")
+	} else {
+		cmds = append(cmds, fmt.Sprintf("-Description '%s'", params.Description))
+	}
+
 	cmd := strings.Join(cmds, " ")
 
 	// Run command

--- a/windows/local/local_group_test.go
+++ b/windows/local/local_group_test.go
@@ -308,7 +308,7 @@ func (suite *LocalUnitTestSuite) TestGroupUpdate() {
 			{
 				"assert with Name parameter",
 				GroupUpdateParams{Name: "Test"},
-				"Set-LocalGroup -Name 'Test' -Description ''",
+				"Set-LocalGroup -Name 'Test' -Description ' '",
 			},
 		}
 


### PR DESCRIPTION
Fixed an issue where the local GroupUpdate function cannot update an empty description.