### PR TITLE
Fix/local user create

### DIFF
--- a/windows/local/local_client.go
+++ b/windows/local/local_client.go
@@ -4,7 +4,7 @@ package local
 import (
 	"context"
 	"encoding/json"
-	"errors"
+	"fmt"
 
 	"github.com/d-strobel/gowindows/connection"
 	"github.com/d-strobel/gowindows/parser"
@@ -50,7 +50,7 @@ func localRun[T localType](ctx context.Context, c *LocalClient, cmd string, l *T
 			return err
 		}
 
-		return errors.New(stderr)
+		return fmt.Errorf("Command:\n%s\n\nPowershell error:\n%s", cmd, stderr)
 	}
 
 	if result.StdOut == "" {

--- a/windows/local/local_client_test.go
+++ b/windows/local/local_client_test.go
@@ -153,7 +153,7 @@ func (suite *LocalUnitTestSuite) TestLocalRun() {
 		}, nil)
 		mockParser.On("DecodeCLIXML", "clixml-error").Return("powershell-error", nil)
 		var g Group
-		expectedErr := errors.New("powershell-error")
+		expectedErr := errors.New("Command:\nGet-LocalGroup -name Userrs\n\nPowershell error:\npowershell-error")
 		err := localRun[Group](ctx, c, expectedCMD, &g)
 		suite.Error(err)
 		suite.Equal(expectedErr, err)

--- a/windows/local/local_user.go
+++ b/windows/local/local_user.go
@@ -159,11 +159,10 @@ func (c *LocalClient) UserCreate(ctx context.Context, params UserCreateParams) (
 
 	if params.Password != "" {
 		cmds = append(cmds, fmt.Sprintf("-Password $(ConvertTo-SecureString -String '%s' -AsPlainText -Force)", params.Password))
+		cmds = append(cmds, fmt.Sprintf("-PasswordNeverExpires:$%t", params.PasswordNeverExpires))
 	} else {
 		cmds = append(cmds, "-NoPassword")
 	}
-
-	cmds = append(cmds, fmt.Sprintf("-PasswordNeverExpires:$%t", params.PasswordNeverExpires))
 
 	if params.UserMayChangePassword {
 		cmds = append(cmds, "-UserMayNotChangePassword:$false")

--- a/windows/local/local_user_test.go
+++ b/windows/local/local_user_test.go
@@ -255,7 +255,7 @@ func (suite *LocalUnitTestSuite) TestUserCreate() {
 			Connection: mockConn,
 			parser:     mockParser,
 		}
-		expectedCMD := "New-LocalUser -Name 'Test-User' -Description 'This is a test user' -AccountExpires $(Get-Date '2025-11-10 16:00:00') -Disabled:$false -FullName 'Full-Test-User' -NoPassword -PasswordNeverExpires:$false -UserMayNotChangePassword:$false | ConvertTo-Json -Compress"
+		expectedCMD := "New-LocalUser -Name 'Test-User' -Description 'This is a test user' -AccountExpires $(Get-Date '2025-11-10 16:00:00') -Disabled:$false -FullName 'Full-Test-User' -NoPassword -UserMayNotChangePassword:$false | ConvertTo-Json -Compress"
 		mockConn.On("Run", ctx, expectedCMD).Return(connection.CMDResult{
 			StdOut: testUser,
 		}, nil)
@@ -282,27 +282,27 @@ func (suite *LocalUnitTestSuite) TestUserCreate() {
 			{
 				"assert user with Name",
 				UserCreateParams{Name: "Tester"},
-				"New-LocalUser -Name 'Tester' -AccountNeverExpires -Disabled -NoPassword -PasswordNeverExpires:$false -UserMayNotChangePassword | ConvertTo-Json -Compress",
+				"New-LocalUser -Name 'Tester' -AccountNeverExpires -Disabled -NoPassword -UserMayNotChangePassword | ConvertTo-Json -Compress",
 			},
 			{
 				"assert user with Name + Description",
 				UserCreateParams{Name: "Tester", Description: "This is a test user"},
-				"New-LocalUser -Name 'Tester' -Description 'This is a test user' -AccountNeverExpires -Disabled -NoPassword -PasswordNeverExpires:$false -UserMayNotChangePassword | ConvertTo-Json -Compress",
+				"New-LocalUser -Name 'Tester' -Description 'This is a test user' -AccountNeverExpires -Disabled -NoPassword -UserMayNotChangePassword | ConvertTo-Json -Compress",
 			},
 			{
 				"assert user with Name + AccountExpires",
 				UserCreateParams{Name: "Tester", AccountExpires: time.Date(2024, time.April, 10, 15, 0, 0, 0, time.UTC)},
-				"New-LocalUser -Name 'Tester' -AccountExpires $(Get-Date '2024-04-10 15:00:00') -Disabled -NoPassword -PasswordNeverExpires:$false -UserMayNotChangePassword | ConvertTo-Json -Compress",
+				"New-LocalUser -Name 'Tester' -AccountExpires $(Get-Date '2024-04-10 15:00:00') -Disabled -NoPassword -UserMayNotChangePassword | ConvertTo-Json -Compress",
 			},
 			{
 				"assert user with Name + Enabled",
 				UserCreateParams{Name: "Tester", Enabled: true},
-				"New-LocalUser -Name 'Tester' -AccountNeverExpires -Disabled:$false -NoPassword -PasswordNeverExpires:$false -UserMayNotChangePassword | ConvertTo-Json -Compress",
+				"New-LocalUser -Name 'Tester' -AccountNeverExpires -Disabled:$false -NoPassword -UserMayNotChangePassword | ConvertTo-Json -Compress",
 			},
 			{
 				"assert user with Name + FullName",
 				UserCreateParams{Name: "Tester", FullName: "Tester1"},
-				"New-LocalUser -Name 'Tester' -AccountNeverExpires -Disabled -FullName 'Tester1' -NoPassword -PasswordNeverExpires:$false -UserMayNotChangePassword | ConvertTo-Json -Compress",
+				"New-LocalUser -Name 'Tester' -AccountNeverExpires -Disabled -FullName 'Tester1' -NoPassword -UserMayNotChangePassword | ConvertTo-Json -Compress",
 			},
 			{
 				"assert user with Name + Password",
@@ -312,7 +312,7 @@ func (suite *LocalUnitTestSuite) TestUserCreate() {
 			{
 				"assert user with Name + PasswordNeverExpires + UserMayNotChangePassword",
 				UserCreateParams{Name: "Tester", PasswordNeverExpires: true, UserMayChangePassword: true},
-				"New-LocalUser -Name 'Tester' -AccountNeverExpires -Disabled -NoPassword -PasswordNeverExpires:$true -UserMayNotChangePassword:$false | ConvertTo-Json -Compress",
+				"New-LocalUser -Name 'Tester' -AccountNeverExpires -Disabled -NoPassword -UserMayNotChangePassword:$false | ConvertTo-Json -Compress",
 			},
 		}
 


### PR DESCRIPTION
Fixed an issue where it was not possible to create a new user without a password.
Added more output for powershell errors.