### PR TITLE
Fix/dotnet time

### DIFF
--- a/parsing/dotnet_time.go
+++ b/parsing/dotnet_time.go
@@ -10,7 +10,9 @@ import (
 // DotnetTime is a custom time type that embeds the time.Time type. It is designed to handle
 // the unmarshalling of dotnet JSON datetime strings in the format "\"/Date(timestamp)/\""
 // when used as a field in a struct that is being unmarshalled from JSON.
-type DotnetTime time.Time
+type DotnetTime struct {
+	time.Time
+}
 
 // UnmarshalJSON implements the json.Unmarshaler interface for the DotnetTime type.
 // It parses a JSON-encoded dotnet JSON datetime string and converts it into a DotnetTime object.
@@ -47,7 +49,7 @@ func (t *DotnetTime) UnmarshalJSON(b []byte) error {
 
 	// Unmarshal unix time into DotnetTime object
 	unixTime := time.Unix(seconds, 0).UTC()
-	*t = DotnetTime(unixTime)
+	*t = DotnetTime{unixTime}
 
 	return nil
 }

--- a/parsing/dotnet_time_test.go
+++ b/parsing/dotnet_time_test.go
@@ -37,8 +37,8 @@ func (suite *DotnetTimeUnitTestSuite) SetupSuite() {
 	`
 	suite.expectedUnmarshaledJSON = TestUnmarshalObject{
 		Name:    "tester",
-		Created: DotnetTime(suite.expectedDatetime),
-		Updated: DotnetTime(suite.expectedDatetime),
+		Created: DotnetTime{Time: suite.expectedDatetime},
+		Updated: DotnetTime{Time: suite.expectedDatetime},
 	}
 }
 
@@ -51,7 +51,7 @@ func (suite *DotnetTimeUnitTestSuite) TestUnmarshalJSON() {
 
 	suite.Run("should unmarshal the dotnet timestring to DotnetTime object", func() {
 		winTime := DotnetTime{}
-		expectedDotnetTime := DotnetTime(suite.expectedDatetime)
+		expectedDotnetTime := DotnetTime{Time: suite.expectedDatetime}
 		err := winTime.UnmarshalJSON([]byte(suite.dotNetDatetime))
 		suite.NoError(err)
 		suite.Equal(expectedDotnetTime, winTime)
@@ -68,5 +68,14 @@ func (suite *DotnetTimeUnitTestSuite) TestUnmarshalJSON() {
 		err := json.Unmarshal([]byte(suite.jsonData), &actualResult)
 		suite.NoError(err)
 		suite.Equal(suite.expectedUnmarshaledJSON, actualResult)
+	})
+}
+
+func (suite *DotnetTimeUnitTestSuite) TestTimeMethods() {
+	suite.Run("should be able to format dotnet time to RFC3389", func() {
+		dotnetTime := DotnetTime{Time: time.Date(2023, time.November, 30, 21, 25, 5, 0, time.UTC)}
+		actualResult := dotnetTime.Format(time.RFC3339)
+		expectedResult := "2023-11-30T21:25:05Z"
+		suite.Equal(expectedResult, actualResult)
 	})
 }

--- a/windows/local/accounts/user_acc_test.go
+++ b/windows/local/accounts/user_acc_test.go
@@ -26,11 +26,11 @@ func (suite *LocalAccTestSuite) TestUser1Read() {
 			Description:            "Built-in account for administering the computer/domain",
 			Enabled:                true,
 			FullName:               "",
-			PasswordChangeableDate: parsing.DotnetTime(time.Date(2023, time.November, 30, 21, 25, 5, 0, time.UTC)),
+			PasswordChangeableDate: parsing.DotnetTime{Time: time.Date(2023, time.November, 30, 21, 25, 5, 0, time.UTC)},
 			PasswordExpires:        parsing.DotnetTime{},
 			UserMayChangePassword:  true,
 			PasswordRequired:       true,
-			PasswordLastSet:        parsing.DotnetTime(time.Date(2023, time.November, 30, 21, 25, 5, 0, time.UTC)),
+			PasswordLastSet:        parsing.DotnetTime{Time: time.Date(2023, time.November, 30, 21, 25, 5, 0, time.UTC)},
 			LastLogon:              parsing.DotnetTime{},
 			Name:                   "Administrator",
 			SID: accounts.SID{
@@ -52,11 +52,11 @@ func (suite *LocalAccTestSuite) TestUser2List() {
 			Description:            "Built-in account for administering the computer/domain",
 			Enabled:                true,
 			FullName:               "",
-			PasswordChangeableDate: parsing.DotnetTime(time.Date(2023, time.November, 30, 21, 25, 5, 0, time.UTC)),
+			PasswordChangeableDate: parsing.DotnetTime{Time: time.Date(2023, time.November, 30, 21, 25, 5, 0, time.UTC)},
 			PasswordExpires:        parsing.DotnetTime{},
 			UserMayChangePassword:  true,
 			PasswordRequired:       true,
-			PasswordLastSet:        parsing.DotnetTime(time.Date(2023, time.November, 30, 21, 25, 5, 0, time.UTC)),
+			PasswordLastSet:        parsing.DotnetTime{Time: time.Date(2023, time.November, 30, 21, 25, 5, 0, time.UTC)},
 			LastLogon:              parsing.DotnetTime{},
 			Name:                   "Administrator",
 			SID: accounts.SID{
@@ -102,7 +102,7 @@ func (suite *LocalAccTestSuite) TestUser3Create() {
 		suite.Equal(accounts.User{Description: "This is a test user"}.Description, g.Description)
 		suite.Equal(accounts.User{FullName: fmt.Sprintf("Full-Test-User-%d", i)}.FullName, g.FullName)
 		suite.Equal(accounts.User{PasswordExpires: parsing.DotnetTime{}}.PasswordExpires, g.PasswordExpires)
-		suite.Equal(accounts.User{AccountExpires: parsing.DotnetTime(time.Date(2025, time.November, 10, 16, 0, 0, 0, time.UTC))}.AccountExpires, g.AccountExpires)
+		suite.Equal(accounts.User{AccountExpires: parsing.DotnetTime{Time: time.Date(2025, time.November, 10, 16, 0, 0, 0, time.UTC)}}.AccountExpires, g.AccountExpires)
 		suite.Equal(accounts.User{UserMayChangePassword: false}.UserMayChangePassword, g.UserMayChangePassword)
 		suite.Equal(accounts.User{Enabled: true}.Enabled, g.Enabled)
 	}

--- a/windows/local/accounts/user_test.go
+++ b/windows/local/accounts/user_test.go
@@ -24,11 +24,11 @@ var (
 		Description:            "Built-in account for administering the computer/domain",
 		Enabled:                true,
 		FullName:               "",
-		PasswordChangeableDate: parsing.DotnetTime(time.Date(2023, time.November, 30, 21, 25, 5, 0, time.UTC)),
+		PasswordChangeableDate: parsing.DotnetTime{Time: time.Date(2023, time.November, 30, 21, 25, 5, 0, time.UTC)},
 		PasswordExpires:        parsing.DotnetTime{},
 		UserMayChangePassword:  true,
 		PasswordRequired:       true,
-		PasswordLastSet:        parsing.DotnetTime(time.Date(2023, time.November, 30, 21, 25, 5, 0, time.UTC)),
+		PasswordLastSet:        parsing.DotnetTime{Time: time.Date(2023, time.November, 30, 21, 25, 5, 0, time.UTC)},
 		LastLogon:              parsing.DotnetTime{},
 		Name:                   "Administrator",
 		SID: SID{
@@ -41,11 +41,11 @@ var (
 			Description:            "Built-in account for administering the computer/domain",
 			Enabled:                true,
 			FullName:               "",
-			PasswordChangeableDate: parsing.DotnetTime(time.Date(2023, time.November, 30, 21, 25, 5, 0, time.UTC)),
+			PasswordChangeableDate: parsing.DotnetTime{Time: time.Date(2023, time.November, 30, 21, 25, 5, 0, time.UTC)},
 			PasswordExpires:        parsing.DotnetTime{},
 			UserMayChangePassword:  true,
 			PasswordRequired:       true,
-			PasswordLastSet:        parsing.DotnetTime(time.Date(2023, time.November, 30, 21, 25, 5, 0, time.UTC)),
+			PasswordLastSet:        parsing.DotnetTime{Time: time.Date(2023, time.November, 30, 21, 25, 5, 0, time.UTC)},
 			LastLogon:              parsing.DotnetTime{},
 			Name:                   "Administrator",
 			SID: SID{
@@ -70,7 +70,7 @@ var (
 		},
 	}
 	expectedTestUser = User{
-		AccountExpires:         parsing.DotnetTime(time.Date(2025, time.November, 10, 16, 0, 0, 0, time.UTC)),
+		AccountExpires:         parsing.DotnetTime{Time: time.Date(2025, time.November, 10, 16, 0, 0, 0, time.UTC)},
 		Description:            "This is a test user",
 		Enabled:                true,
 		FullName:               "Full-Test-User",


### PR DESCRIPTION
Fixed an issue with the DotnetTime type. It does not embedded the time.Time methods which are needed for the terraform-provider-windows. 